### PR TITLE
add ability to pass more verilog files to the simulator

### DIFF
--- a/example/test.py
+++ b/example/test.py
@@ -1,4 +1,4 @@
-from nmigen_cocotb import run
+from nmigen_cocotb import run, get_current_module
 from toplevel import design, ports
 
 import cocotb
@@ -9,7 +9,7 @@ def just_a_timer(dut):
     yield Timer(10, 'ns')
 
 def test_module():
-    run(design, 'test', ports=ports, vcd_file='output.vcd')
+    run(design, get_current_module(), ports=ports, vcd_file='output.vcd')
 
 if __name__ == '__main__':
     test_module()

--- a/nmigen_cocotb.py
+++ b/nmigen_cocotb.py
@@ -1,5 +1,6 @@
 import argparse
 from cocotb_test.run import run as cocotb_run
+from cocotb_test.simulator import Icarus
 from nmigen import Fragment
 from nmigen.back import verilog
 from nmigen.cli import main_parser, main_runner
@@ -7,6 +8,7 @@ import subprocess
 import tempfile
 import os
 import shutil
+import inspect
 
 
 compile_args_waveforms = ['-s', 'cocotb_waveform_module']
@@ -21,6 +23,10 @@ module cocotb_waveform_module;
    end
 endmodule
 """
+
+def get_current_module():
+    module = inspect.getmodule(inspect.stack()[1][0])
+    return module.__name__
 
 def get_reset_signal(dut, cd):
     return getattr(dut, cd + '_rst')
@@ -60,7 +66,8 @@ def run(design, module, platform=None, ports=(), name='top', vcd_file=None):
         verilog_file = d + '/nmigen_output.v'
         generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
         os.environ['SIM'] = 'icarus'
-        cocotb_run(toplevel=name,
+        cocotb_run(simulator=Icarus,
+                   toplevel=name,
                    module=module,
                    verilog_sources=[verilog_file],
                    compile_args=compile_args_waveforms if vcd_file else [])

--- a/nmigen_cocotb.py
+++ b/nmigen_cocotb.py
@@ -55,14 +55,14 @@ def generate_verilog(verilog_file, design, platform, name='top', ports=(), vcd_f
             vcd_file = os.path.abspath(vcd_file)
             f.write(verilog_waveforms.format(vcd_file, name))
 
-def run(design, module, platform=None, ports=(), name='top', vcd_file=None):
+def run(design, module, platform=None, ports=(), name='top', vcd_file=None, extra_verilog_files=[]):
     with tempfile.TemporaryDirectory() as d:
         verilog_file = d + '/nmigen_output.v'
         generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
         os.environ['SIM'] = 'icarus'
         cocotb_run(toplevel=name,
                    module=module,
-                   verilog_sources=[verilog_file],
+                   verilog_sources=[verilog_file]+extra_verilog_files,
                    compile_args=compile_args_waveforms if vcd_file else [])
 
 def cocotb_runner(parser, args, design, platform=None, name="top", ports=()):


### PR DESCRIPTION
This is needed for using vendor primitives or existing verilog sources.

```python3
def test_module():
    run(design.m,
        'Cosine_test',
        ports=design.ports,
        vcd_file='output.vcd',
        extra_verilog_files=[
            os.path.expandvars("$XPRIMS/RAMB36E1.v"),
            os.path.expandvars("$XPRIMS/DSP48E1.v"),
        ]
    )
```