### PR TITLE
posibility to add non-verilog files to the test path

### DIFF
--- a/nmigen_cocotb.py
+++ b/nmigen_cocotb.py
@@ -61,15 +61,18 @@ def generate_verilog(verilog_file, design, platform, name='top', ports=(), vcd_f
             vcd_file = os.path.abspath(vcd_file)
             f.write(verilog_waveforms.format(vcd_file, name))
 
-def run(design, module, platform=None, ports=(), name='top', vcd_file=None):
+def run(design, module, platform=None, ports=(), name='top', verilog_sources=None, vcd_file=None):
     with tempfile.TemporaryDirectory() as d:
         verilog_file = d + '/nmigen_output.v'
+        sources = [verilog_file]
+        if verilog_sources:
+            sources.extend(verilog_sources)
         generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
         os.environ['SIM'] = 'icarus'
         cocotb_run(simulator=Icarus,
                    toplevel=name,
                    module=module,
-                   verilog_sources=[verilog_file],
+                   verilog_sources=sources,
                    compile_args=compile_args_waveforms if vcd_file else [])
 
 def cocotb_runner(parser, args, design, platform=None, name="top", ports=()):

--- a/nmigen_cocotb.py
+++ b/nmigen_cocotb.py
@@ -61,19 +61,26 @@ def generate_verilog(verilog_file, design, platform, name='top', ports=(), vcd_f
             vcd_file = os.path.abspath(vcd_file)
             f.write(verilog_waveforms.format(vcd_file, name))
 
-def run(design, module, platform=None, ports=(), name='top', verilog_sources=None, vcd_file=None):
+def copy_rom_files(rom_sources, path):
+    for f in rom_sources:
+        shutil.copy(f, path)
+
+def run(design, module, platform=None, ports=(), name='top', verilog_sources=None, rom_sources=None, vcd_file=None):
     with tempfile.TemporaryDirectory() as d:
         verilog_file = d + '/nmigen_output.v'
+        generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
         sources = [verilog_file]
         if verilog_sources:
             sources.extend(verilog_sources)
-        generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
+        if rom_sources:
+            copy_rom_files(rom_sources, d)
         os.environ['SIM'] = 'icarus'
         cocotb_run(simulator=Icarus,
                    toplevel=name,
                    module=module,
                    verilog_sources=sources,
-                   compile_args=compile_args_waveforms if vcd_file else [])
+                   compile_args=compile_args_waveforms if vcd_file else [],
+                   sim_build=d)
 
 def cocotb_runner(parser, args, design, platform=None, name="top", ports=()):
     if args.action == "cocotb":

--- a/nmigen_cocotb.py
+++ b/nmigen_cocotb.py
@@ -61,19 +61,19 @@ def generate_verilog(verilog_file, design, platform, name='top', ports=(), vcd_f
             vcd_file = os.path.abspath(vcd_file)
             f.write(verilog_waveforms.format(vcd_file, name))
 
-def copy_rom_files(rom_sources, path):
-    for f in rom_sources:
+def copy_extra_files(extra_files, path):
+    for f in extra_files:
         shutil.copy(f, path)
 
-def run(design, module, platform=None, ports=(), name='top', verilog_sources=None, rom_sources=None, vcd_file=None):
+def run(design, module, platform=None, ports=(), name='top', verilog_sources=None, extra_files=None, vcd_file=None):
     with tempfile.TemporaryDirectory() as d:
         verilog_file = d + '/nmigen_output.v'
         generate_verilog(verilog_file, design, platform, name, ports, vcd_file)
         sources = [verilog_file]
         if verilog_sources:
             sources.extend(verilog_sources)
-        if rom_sources:
-            copy_rom_files(rom_sources, d)
+        if extra_files:
+            copy_extra_files(extra_files, d)
         os.environ['SIM'] = 'icarus'
         cocotb_run(simulator=Icarus,
                    toplevel=name,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     py_modules=['nmigen_cocotb'],
     setup_requires=['cocotb'],
     install_requires=['cocotb-test @ git+https://github.com/themperek/cocotb-test.git#egg=cocotb-test',
-                      'nmigen @ git+https://github.com/m-labs/nmigen.git#egg=nmigen'],
+                      'nmigen @ git+https://github.com/nmigen/nmigen.git@master#egg=nmigen'],
     #dependency_links=['git+https://github.com/m-labs/nmigen.git#egg=nmigen',
                       #'git+https://github.com/themperek/cocotb-test.git#egg=cocotb-test']
 )


### PR DESCRIPTION
Add the posibility to add non-verilog files to the test path (useful for mem init files).

Also, silently updated nmigen dependency from m-labs/nmigen to nmigen/nmigen.
