### PR TITLE
port nmigen -> amaranth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nMigen-cocotb
 
-nMigen-cocotb is a simple python module which tries to combine
-two amazing HDL tools: nMigen and cocotb
+amaranth-cocotb is a simple python module which tries to combine
+two amazing HDL tools: amaranth (former nMigen) and Cocotb.
 
 # Installation
 

--- a/amaranth_cocotb/__init__.py
+++ b/amaranth_cocotb/__init__.py
@@ -1,0 +1,1 @@
+from .amaranth_cocotb import *

--- a/example/test.py
+++ b/example/test.py
@@ -1,17 +1,18 @@
-from nmigen_cocotb import run, get_current_module
+from amaranth_cocotb import run, get_current_module
 from toplevel import design, ports
 
 import cocotb
 from cocotb.triggers import Timer
 
+
 @cocotb.test()
-def just_a_timer(dut):
-    yield Timer(10, 'ns')
+async def just_a_timer(dut):
+    await Timer(10, 'ns')
+
 
 def test_module():
     run(design, get_current_module(), ports=ports, vcd_file='output.vcd')
 
+
 if __name__ == '__main__':
     test_module()
-    
-    

--- a/example/toplevel.py
+++ b/example/toplevel.py
@@ -1,5 +1,5 @@
-from nmigen import *
-from nmigen_cocotb import main
+from amaranth import Module, Signal
+from amaranth_cocotb import main
 
 design = Module()
 a = Signal()

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="nmigen_cocotb",
-    version="0.1",
+    name='amaranth-cocotb',
     author='Andres Demski',
-    py_modules=['nmigen_cocotb'],
+    packages=find_packages(),
     setup_requires=['cocotb'],
-    install_requires=['cocotb-test @ git+https://github.com/themperek/cocotb-test.git#egg=cocotb-test',
-                      'nmigen @ git+https://github.com/nmigen/nmigen.git@master#egg=nmigen'],
-    #dependency_links=['git+https://github.com/m-labs/nmigen.git#egg=nmigen',
-                      #'git+https://github.com/themperek/cocotb-test.git#egg=cocotb-test']
+    install_requires=[
+        'cocotb-test',
+        'amaranth @ git+https://github.com/amaranth-lang/amaranth.git#egg=amaranth',
+        'amaranth-yosys'
+    ]
 )


### PR DESCRIPTION
Changes:
* replace nMigen with its new name amaranth  (https://github.com/amaranth-lang/amaranth).
* Migrated from `@cocotb.coroutine/yield` to `async/await`
* Added `extra_env` parameter support.
* Lint