### PR TITLE
Fixed error caused by change to the parent class of Icarus_g2005.

### DIFF
--- a/amaranth_cocotb/amaranth_cocotb.py
+++ b/amaranth_cocotb/amaranth_cocotb.py
@@ -6,21 +6,24 @@ import tempfile
 import os
 import shutil
 import inspect
-
+import re
 
 class Icarus_g2005(Icarus):
     def compile_command(self):
+        def set_verilog_version_to(new_ver, old_cmds):
+            new_cmds = []
+            for each_cmd in old_cmds:
+                version_string_match = re.search("-g20..", each_cmd) # e.g. matches -g2012
+                if version_string_match == None:
+                    new_cmds.append(each_cmd)
+                else:
+                    new_cmds.append(each_cmd.replace(version_string_match.group(0), "-g2005"))
+            return new_cmds
 
-        cmd_compile = (
-            ["iverilog", "-o", self.sim_file, "-D", "COCOTB_SIM=1", "-s",
-             self.toplevel, "-g2005"]
-            + self.get_define_commands(self.defines)
-            + self.get_include_commands(self.includes)
-            + self.compile_args
-            + self.verilog_sources
-        )
-
-        return cmd_compile
+        old_cmds = super().compile_command()
+        new_ver = "-g2005"
+        new_cmds = set_verilog_version_to(new_ver, old_cmds)
+        return new_cmds
 
 
 compile_args_waveforms = ['-s', 'cocotb_waveform_module']


### PR DESCRIPTION
The error I got was that self.compile_args is now a dictionary,
rather than an array. Although self.compile_args_flattened seemed
to work, I wasn't sure if there were other changes in the parent
class that I didn't find.

So this commit was implemented to reduce the reliance on the internal
structure of the parent class.